### PR TITLE
chore(cli): update build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-n": "^16.0.2",
     "path-scurry": "^1.10.1",
     "picocolors": "^1.0.0",
+    "rimraf": "^5.0.1",
     "turbo": "^1.10.13",
     "type-fest": "^4.2.0",
     "typescript": "^5.1.6"

--- a/packages/tools/cli/package.json
+++ b/packages/tools/cli/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/SukkaW/nolyfill",
   "scripts": {
     "canary": "node -r @swc-node/register src/index.ts",
-    "build": "rollup -c rollup.config.ts --configPlugin swc3"
+    "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin swc3"
   },
   "engines": {
     "node": ">=12.4.0"

--- a/packages/tools/cli/package.json
+++ b/packages/tools/cli/package.json
@@ -31,7 +31,7 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.2.0",
     "@swc-node/register": "^1.6.6",
-    "@swc/core": "^1.3.78",
+    "@swc/core": "^1.3.83",
     "@swc/helpers": "^0.5.1",
     "@types/npmcli__arborist": "^5.6.1",
     "@types/treeverse": "^3.0.1",

--- a/packages/tools/cli/rollup.config.ts
+++ b/packages/tools/cli/rollup.config.ts
@@ -43,7 +43,8 @@ export default async () => {
         esModule: false,
         // graceful-fs requires patching fs exports, so we must allow fs exports to be modified
         externalLiveBindings: false,
-        freeze: false
+        freeze: false,
+        hoistTransitiveImports: false
       },
       plugins: [
         nodeResolve({
@@ -113,17 +114,15 @@ export default async () => {
           }
         },
         swc({
-        // minify: true,
+          minify: true,
           jsc: {
             externalHelpers: true,
             minify: {
-            // https://github.com/swc-project/swc/issues/7847
-              compress: false,
-              // compress: {
-              //   passes: 2,
-              //   sequences: false,
-              //   hoist_props: false
-              // },
+              compress: {
+                passes: 2,
+                sequences: false,
+                hoist_props: false
+              },
               mangle: true,
               module: true
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,7 +510,7 @@ importers:
         version: 5.0.2(rollup@3.28.0)
       '@swc/core':
         specifier: ^1.3.76
-        version: 1.3.78(@swc/helpers@0.5.1)
+        version: 1.3.78
       ljharb-es-iterator-helpers:
         specifier: npm:es-iterator-helpers@^1.0.14
         version: /es-iterator-helpers@1.0.14
@@ -570,10 +570,10 @@ importers:
         version: 15.2.0(rollup@3.28.0)
       '@swc-node/register':
         specifier: ^1.6.6
-        version: 1.6.6(@swc/core@1.3.78)(typescript@5.2.2)
+        version: 1.6.6(@swc/core@1.3.83)(typescript@5.2.2)
       '@swc/core':
-        specifier: ^1.3.78
-        version: 1.3.78(@swc/helpers@0.5.1)
+        specifier: ^1.3.83
+        version: 1.3.83(@swc/helpers@0.5.1)
       '@swc/helpers':
         specifier: ^0.5.1
         version: 0.5.1
@@ -606,7 +606,7 @@ importers:
         version: 6.0.1(rollup@3.28.0)(typescript@5.2.2)
       rollup-plugin-swc3:
         specifier: ^0.9.1
-        version: 0.9.1(@swc/core@1.3.78)(rollup@3.28.0)
+        version: 0.9.1(@swc/core@1.3.83)(rollup@3.28.0)
       rollup-plugin-visualizer:
         specifier: ^5.9.2
         version: 5.9.2(rollup@3.28.0)
@@ -1684,24 +1684,24 @@ packages:
       - supports-color
     dev: true
 
-  /@swc-node/core@1.10.5(@swc/core@1.3.78):
+  /@swc-node/core@1.10.5(@swc/core@1.3.83):
     resolution: {integrity: sha512-G+Me0sTApMy6WY9mT0TluFxdO633P1GWMllbT3LWeJlknqQxJo8dAQcV0Uc0+rvBVXt7rRo/BMUZNJp88qarzg==}
     engines: {node: '>= 10'}
     peerDependencies:
       '@swc/core': '>= 1.3'
     dependencies:
-      '@swc/core': 1.3.78(@swc/helpers@0.5.1)
+      '@swc/core': 1.3.83(@swc/helpers@0.5.1)
     dev: true
 
-  /@swc-node/register@1.6.6(@swc/core@1.3.78)(typescript@5.2.2):
+  /@swc-node/register@1.6.6(@swc/core@1.3.83)(typescript@5.2.2):
     resolution: {integrity: sha512-KgnQrWLgtJzEgPpxvhOPUDonv1xreVumGdzXDQlDVIqU3vH+spW8ZYxxyjJVMh3G/mQG8E3bFvUMHIS+E3FL2w==}
     peerDependencies:
       '@swc/core': '>= 1.3'
       typescript: '>= 4.3'
     dependencies:
-      '@swc-node/core': 1.10.5(@swc/core@1.3.78)
+      '@swc-node/core': 1.10.5(@swc/core@1.3.83)
       '@swc-node/sourcemap-support': 0.3.0
-      '@swc/core': 1.3.78(@swc/helpers@0.5.1)
+      '@swc/core': 1.3.83(@swc/helpers@0.5.1)
       colorette: 2.0.20
       debug: 4.3.4
       pirates: 4.0.6
@@ -1727,8 +1727,26 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-darwin-arm64@1.3.83:
+    resolution: {integrity: sha512-Plz2IKeveVLivbXTSCC3OZjD2MojyKYllhPrn9RotkDIZEFRYJZtW5/Ik1tJW/2rzu5HVKuGYrDKdScVVTbOxQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-darwin-x64@1.3.78:
     resolution: {integrity: sha512-w0RsD1onQAj0vuLAoOVi48HgnW6D6oBEIZP17l0HYejCDBZ+FRZLjml7wgNAWMqHcd2qNRqgtZ+v7aLza2JtBQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.3.83:
+    resolution: {integrity: sha512-FBGVg5IPF/8jQ6FbK60iDUHjv0H5+LwfpJHKH6wZnRaYWFtm7+pzYgreLu3NTsm3m7/1a7t0+7KURwBGUaJCCw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -1745,8 +1763,26 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-arm-gnueabihf@1.3.83:
+    resolution: {integrity: sha512-EZcsuRYhGkzofXtzwDjuuBC/suiX9s7zeg2YYXOVjWwyebb6BUhB1yad3mcykFQ20rTLO9JUyIaiaMYDHGobqw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-arm64-gnu@1.3.78:
     resolution: {integrity: sha512-Sis17dz9joJRFVvR/gteOZSUNrrrioo81RQzani0Zr5ZZOfWLMTB9DA+0MVlfnVa2taYcsJHJZFoAv9JkLwbzg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.3.83:
+    resolution: {integrity: sha512-khI41szLHrCD/cFOcN4p2SYvZgHjhhHlcMHz5BksRrDyteSJKu0qtWRZITVom0N/9jWoAleoFhMnFTUs0H8IWA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1763,8 +1799,26 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-arm64-musl@1.3.83:
+    resolution: {integrity: sha512-zgT7yNOdbjHcGAwvys79mbfNLK65KBlPJWzeig+Yk7I8TVzmaQge7B6ZS/gwF9/p+8TiLYo/tZ5aF2lqlgdSVw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-x64-gnu@1.3.78:
     resolution: {integrity: sha512-iDxa+RknnTQlyy+WfPor1FM6y44ERNI2E0xiUV6gV6uPwegCngi8LFC+E7IvP6+p+yXtAkesunAaiZ8nn0s+rw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.3.83:
+    resolution: {integrity: sha512-x+mH0Y3NC/G0YNlFmGi3vGD4VOm7IPDhh+tGrx6WtJp0BsShAbOpxtfU885rp1QweZe4qYoEmGqiEjE2WrPIdA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1781,8 +1835,26 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-linux-x64-musl@1.3.83:
+    resolution: {integrity: sha512-s5AYhAOmetUwUZwS5g9qb92IYgNHHBGiY2mTLImtEgpAeBwe0LPDj6WrujxCBuZnaS55mKRLLOuiMZE5TpjBNA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-arm64-msvc@1.3.78:
     resolution: {integrity: sha512-CXFaGEc2M9Su3UoUMC8AnzKb9g+GwPxXfakLWZsjwS448h6jcreExq3nwtBNdVGzQ26xqeVLMFfb1l/oK99Hwg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.3.83:
+    resolution: {integrity: sha512-yw2rd/KVOGs95lRRB+killLWNaO1dy4uVa8Q3/4wb5txlLru07W1m041fZLzwOg/1Sh0TMjJgGxj0XHGR3ZXhQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -1799,6 +1871,15 @@ packages:
     dev: true
     optional: true
 
+  /@swc/core-win32-ia32-msvc@1.3.83:
+    resolution: {integrity: sha512-POW+rgZ6KWqBpwPGIRd2/3pcf46P+UrKBm4HLt5IwbHvekJ4avIM8ixJa9kK0muJNVJcDpaZgxaU1ELxtJ1j8w==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-x64-msvc@1.3.78:
     resolution: {integrity: sha512-oYxa+tPdhlx1aH14AIoF6kvVjo49tEOW0drNqoEaVHufvgH0y43QU2Jum3b2+xXztmMRtzK2CSN3GPOAXDKKKg==}
     engines: {node: '>=10'}
@@ -1808,7 +1889,16 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core@1.3.78(@swc/helpers@0.5.1):
+  /@swc/core-win32-x64-msvc@1.3.83:
+    resolution: {integrity: sha512-CiWQtkFnZElXQUalaHp+Wacw0Jd+24ncRYhqaJ9YKnEQP1H82CxIIuQqLM8IFaLpn5dpY6SgzaeubWF46hjcLA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core@1.3.78:
     resolution: {integrity: sha512-y6DQP571v7fbUUY7nz5G4lNIRGofuO48K5pGhD9VnuOCTuptfooCdi8wnigIrIhM/M4zQ53m/YCMDCbOtDgEww==}
     engines: {node: '>=10'}
     requiresBuild: true
@@ -1817,8 +1907,6 @@ packages:
     peerDependenciesMeta:
       '@swc/helpers':
         optional: true
-    dependencies:
-      '@swc/helpers': 0.5.1
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.3.78
       '@swc/core-darwin-x64': 1.3.78
@@ -1832,10 +1920,39 @@ packages:
       '@swc/core-win32-x64-msvc': 1.3.78
     dev: true
 
+  /@swc/core@1.3.83(@swc/helpers@0.5.1):
+    resolution: {integrity: sha512-PccHDgGQlFjpExgJxH91qA3a4aifR+axCFJ4RieCoiI0m5gURE4nBhxzTBY5YU/YKTBmPO8Gc5Q6inE3+NquWg==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': ^0.5.0
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/helpers': 0.5.1
+      '@swc/types': 0.1.4
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.3.83
+      '@swc/core-darwin-x64': 1.3.83
+      '@swc/core-linux-arm-gnueabihf': 1.3.83
+      '@swc/core-linux-arm64-gnu': 1.3.83
+      '@swc/core-linux-arm64-musl': 1.3.83
+      '@swc/core-linux-x64-gnu': 1.3.83
+      '@swc/core-linux-x64-musl': 1.3.83
+      '@swc/core-win32-arm64-msvc': 1.3.83
+      '@swc/core-win32-ia32-msvc': 1.3.83
+      '@swc/core-win32-x64-msvc': 1.3.83
+    dev: true
+
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.6.2
+    dev: true
+
+  /@swc/types@0.1.4:
+    resolution: {integrity: sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==}
     dev: true
 
   /@tootallnate/once@2.0.0:
@@ -4690,10 +4807,25 @@ packages:
     dependencies:
       '@fastify/deepmerge': 1.3.0
       '@rollup/pluginutils': 4.2.1
-      '@swc/core': 1.3.78(@swc/helpers@0.5.1)
+      '@swc/core': 1.3.78
       get-tsconfig: 4.7.0
       rollup: 3.28.0
       rollup-swc-preserve-directives: 0.3.2(@swc/core@1.3.78)(rollup@3.28.0)
+    dev: true
+
+  /rollup-plugin-swc3@0.9.1(@swc/core@1.3.83)(rollup@3.28.0):
+    resolution: {integrity: sha512-vEWpSOmWHfgNANgZ4a1+KAH8fhwfgSXAwOsIC8d3Spj0Th9PkMxREhurXkmCqLYqX5vXi2cW4MUG+cSGIhtyyg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@swc/core': '>=1.2.165'
+      rollup: ^2.0.0 || ^3.0.0
+    dependencies:
+      '@fastify/deepmerge': 1.3.0
+      '@rollup/pluginutils': 4.2.1
+      '@swc/core': 1.3.83(@swc/helpers@0.5.1)
+      get-tsconfig: 4.7.0
+      rollup: 3.28.0
+      rollup-swc-preserve-directives: 0.3.2(@swc/core@1.3.83)(rollup@3.28.0)
     dev: true
 
   /rollup-plugin-visualizer@5.9.2(rollup@3.28.0):
@@ -4720,7 +4852,18 @@ packages:
       rollup: ^2.0.0 || ^3.0.0
     dependencies:
       '@napi-rs/magic-string': 0.3.4
-      '@swc/core': 1.3.78(@swc/helpers@0.5.1)
+      '@swc/core': 1.3.78
+      rollup: 3.28.0
+    dev: true
+
+  /rollup-swc-preserve-directives@0.3.2(@swc/core@1.3.83)(rollup@3.28.0):
+    resolution: {integrity: sha512-W0zljPCOMFErWUweRvnN9LCNrII2KzjAw9iZUNM1kZdf3rwQGQQiaCPnH4ugu3UIj1b+zEJKee20S8Ozgwh8Wg==}
+    peerDependencies:
+      '@swc/core': '>=1.2.165'
+      rollup: ^2.0.0 || ^3.0.0
+    dependencies:
+      '@napi-rs/magic-string': 0.3.4
+      '@swc/core': 1.3.83(@swc/helpers@0.5.1)
       rollup: 3.28.0
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0
+      rimraf:
+        specifier: ^5.0.1
+        version: 5.0.1
       turbo:
         specifier: ^1.10.13
         version: 1.10.13
@@ -4782,6 +4785,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
+
+  /rimraf@5.0.1:
+    resolution: {integrity: sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      glob: 10.3.4
     dev: true
 
   /rollup-plugin-dts@6.0.1(rollup@3.28.0)(typescript@5.2.2):


### PR DESCRIPTION
- The PR enables the swc compress for cli/sdk build
  - swc has been updated to the latest version, to include the bugfix for https://github.com/swc-project/swc/issues/7847.
- The PR disables `hoistTransitiveImports` for cli/sdk build
  - This option is quite helpful with web apps, but not useful for Node.js apps.
- The PR adds `rimraf dist` before rollup
  - After #27, the build now outputs more than one chunk, thus we can no longer rely on rollup overwriting the existing files.