### PR TITLE
perf: use `fast-npm-meta`

### DIFF
--- a/packages/tools/cli/package.json
+++ b/packages/tools/cli/package.json
@@ -36,6 +36,7 @@
     "@yarnpkg/parsers": "3.0.0",
     "commander": "^11.1.0",
     "detect-indent": "^6.1.0",
+    "fast-npm-meta": "^0.2.1",
     "picocolors": "^1.0.0",
     "rollup-plugin-visualizer": "^5.12.0"
   },

--- a/packages/tools/cli/src/check-update.ts
+++ b/packages/tools/cli/src/check-update.ts
@@ -2,11 +2,10 @@ import { join } from 'path';
 import fs from 'fs';
 import fsp from 'fs/promises';
 import { tmpdir } from 'os';
-import https from 'https';
-import http from 'http';
 import { env } from 'process';
 import picocolors from 'picocolors';
-import type { PackageJson } from 'type-fest';
+
+import { getLatestVersion } from 'fast-npm-meta';
 
 const UPDATE_CHECK_INTERVAL = 3_600_000;
 const UPDATE_CHECK_DIST_TAG = 'latest';
@@ -53,61 +52,6 @@ const updateCache = (file: string, latest: string | null, lastUpdate: number) =>
   return fsp.writeFile(file, content, 'utf8');
 };
 
-const loadPackage = (url: URL) => new Promise<PackageJson>((resolve, reject) => {
-  const options: https.RequestOptions = {
-    host: url.hostname,
-    path: url.pathname,
-    port: url.port,
-    headers: {
-      accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
-    },
-    timeout: 2000
-  };
-
-  const { get } = url.protocol === 'https:' ? https : http;
-  get(options, response => {
-    const { statusCode } = response;
-
-    if (statusCode !== 200) {
-      const error = new Error(`Request failed with code ${statusCode}`);
-      Object.defineProperty(error, 'code', { value: statusCode });
-
-      reject(error);
-
-      // Consume response data to free up RAM
-      response.resume();
-      return;
-    }
-
-    let rawData = '';
-    response.setEncoding('utf8');
-
-    response.on('data', chunk => {
-      rawData += chunk;
-    });
-
-    response.on('end', () => {
-      try {
-        const parsedData = JSON.parse(rawData);
-        resolve(parsedData);
-      } catch (e) {
-        reject(e);
-      }
-    });
-  }).on('error', reject).on('timeout', reject);
-});
-
-const getMostRecent = async (distTag: string): Promise<string | null> => {
-  const url = new URL(`https://registry.npmjs.org/nolyfill/${distTag}`);
-
-  try {
-    const spec = await loadPackage(url);
-    return spec.version ?? null;
-  } catch {
-    return null;
-  }
-};
-
 export const checkForUpdates = async (name: string, currentVersion: string): Promise<void> => {
   // Do not check for updates if the `NO_UPDATE_CHECK` variable is set.
   if (env.NO_UPDATE_CHECK) return;
@@ -128,7 +72,7 @@ export const checkForUpdates = async (name: string, currentVersion: string): Pro
   ({ shouldCheck, latest } = await evaluateCache(file, time, UPDATE_CHECK_INTERVAL));
 
   if (shouldCheck) {
-    latest = (await getMostRecent(UPDATE_CHECK_DIST_TAG)) ?? null;
+    latest = (await getLatestVersion(`nolyfill@${UPDATE_CHECK_DIST_TAG}`)).version;
     // If we pulled an update, we need to update the cache
     await updateCache(file, latest, time);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
       detect-indent:
         specifier: ^6.1.0
         version: 6.1.0
+      fast-npm-meta:
+        specifier: ^0.2.1
+        version: 0.2.1
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2562,6 +2565,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-npm-meta@0.2.1:
+    resolution: {integrity: sha512-Iheh2ZXfpZ6lHO6+8wdo0sW4DUWZGw6e5t0Vp2jcTX+HNlneboxxBjLffa3E9ZWHyu8ZsGmd/GcoORKpq03UQA==}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -6074,6 +6080,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-npm-meta@0.2.1: {}
 
   fast-safe-stringify@2.1.1: {}
 


### PR DESCRIPTION
Use @antfu's awesome and performant `fast-npm-meta` for checking nolyfill CLI updates.