### PR TITLE
fix: fix prefix-only modules not correctly recognized as builtin

### DIFF
--- a/packages/data/single-file/src/is-core-module.ts
+++ b/packages/data/single-file/src/is-core-module.ts
@@ -12,7 +12,6 @@ export default function isCore(x: string, _nodeVersion: unknown) {
     || (
       typeof x === 'string'
       && x.startsWith('node:')
-      && publicBuiltinIds.has(x.slice(5))
     )
   );
 }


### PR DESCRIPTION
Following https://github.com/import-js/eslint-import-resolver-typescript/pull/295#issuecomment-2231939714, a fix has been implemented. I believe that once we have a module which name starts with `node:`, it's already safe to assume it's a builtin module.