### PR TITLE
fix(#104): proper `function.prototype.name` implementation

### DIFF
--- a/packages/data/es-shim-like/src/function.prototype.name.ts
+++ b/packages/data/es-shim-like/src/function.prototype.name.ts
@@ -1,3 +1,3 @@
 import { defineEsShim } from '@nolyfill/shared';
 
-export default defineEsShim(Function.prototype.name);
+export default defineEsShim<Function, (this: Function) => string>(function functionPrototypeName() { return this.name; });

--- a/packages/generated/function.prototype.name/entry.js
+++ b/packages/generated/function.prototype.name/entry.js
@@ -1,2 +1,2 @@
-"use strict";Object.defineProperty(exports,"__esModule",{value:!0}),Object.defineProperty(exports,"default",{enumerable:!0,get:function(){return e}});const e=(0,require("@nolyfill/shared").defineEsShim)(Function.prototype.name);
+"use strict";Object.defineProperty(exports,"__esModule",{value:!0}),Object.defineProperty(exports,"default",{enumerable:!0,get:function(){return e}});const e=(0,require("@nolyfill/shared").defineEsShim)(function(){return this.name});
 Object.assign(exports.default, exports); module.exports = exports.default;

--- a/packages/generated/function.prototype.name/package.json
+++ b/packages/generated/function.prototype.name/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nolyfill/function.prototype.name",
-  "version": "1.0.28",
+  "version": "1.0.40",
   "repository": {
     "type": "git",
     "url": "https://github.com/SukkaW/nolyfill",


### PR DESCRIPTION
`Function.prototype.name` is the `name` of the `Function.prototype`. The PR replaces the implementation with a proper getter.

I simply ignore any detection (`this === Function.prototype` or `Object.hasOwn(this, 'name')`) since nolyfill already assumes the runtime has the proper implementation.

cc @jdalton 