### PR TITLE
Fix: Can't find right `pnpm-lock.yaml` version when using quotes is double.

### DIFF
--- a/packages/tools/cli/src/lockfile/index.ts
+++ b/packages/tools/cli/src/lockfile/index.ts
@@ -2,8 +2,8 @@ import type { PackageManager } from '../package-manager';
 import { buildPNPMDepTree } from './pnpm';
 import { buildNPMDepTree } from './npm';
 import { buildYarnDepTree } from './yarn';
-import fsp from 'fs/promises';
-import path from 'path';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
 
 export interface PackageLockDeps {
   [depName: string]: PackageLockDep
@@ -34,10 +34,9 @@ export function buildDepTrees(packageManager: PackageManager, dir: string) {
 
 export async function getPNPMLockfileVersion(dir: string) {
   const content = await fsp.readFile(path.resolve(dir, 'pnpm-lock.yaml'), 'utf-8');
-  const [, lockfileVersion] = content.match(/^lockfileVersion: '?(\d*(?:.\d*)?)'?$/m) ?? [];
+  const [, lockfileVersion] = (/^lockfileVersion: ["']?(\d*(?:\.\d*)?)["']?$/m.exec(content)) ?? [];
 
-  if (!lockfileVersion)
-    throw new Error(`Can't detect lockfile version`)
+  if (!lockfileVersion) throw new Error('Can\'t detect lockfile version');
 
   return lockfileVersion;
 }


### PR DESCRIPTION
## TL;DR

I'm using `dprint` as my local code formatter, It support format `yaml` file so my local `pnpm-lock.yaml` each value is wrapper by "double quotes". this pull request is to fix the problem.